### PR TITLE
[#7] Replace `handlebars` with `handlebars-engine`

### DIFF
--- a/lib/tilt/handlebars.rb
+++ b/lib/tilt/handlebars.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "handlebars"
+require "handlebars/engine"
 require "pathname"
-require "tilt" unless defined? Tilt
+require "tilt"
 
 module Tilt
   # Handlebars.rb template implementation. See:
@@ -21,9 +21,9 @@ module Tilt
     end
 
     def prepare
-      @context = ::Handlebars::Context.new
-      @context.partial_missing { |partial_name| load_partial partial_name }
-      @template = @context.compile(data)
+      @engine = ::Handlebars::Engine.new
+      @engine.register_partial_missing { |name| load_partial(name) }
+      @template = @engine.compile(data)
     end
 
     # rubocop:disable Metrics/AbcSize
@@ -47,16 +47,16 @@ module Tilt
     end
     # rubocop:enable Metrics/AbcSize
 
-    def register_helper(name, &fn)
-      @context.register_helper(name, &fn)
+    def register_helper(*args, **opts, &block)
+      @engine.register_helper(*args, **opts, &block)
     end
 
-    def register_partial(*args)
-      @context.register_partial(*args)
+    def register_partial(*args, **opts, &block)
+      @engine.register_partial(*args, **opts, &block)
     end
 
-    def partial_missing(&fn)
-      @context.partial_missing(&fn)
+    def partial_missing(*args, **opts, &block)
+      @engine.register_partial_missing(*args, **opts, &block)
     end
 
     def allows_script?

--- a/test/tilt_handlebarstemplate_test.rb
+++ b/test/tilt_handlebarstemplate_test.rb
@@ -136,26 +136,30 @@ describe Tilt::HandlebarsTemplate do
 
     it "applies block helper to static text" do
       template = make_template "{{#upper}}Hello, World.{{/upper}}"
-      template.register_helper(:upper) do |this, block|
-        block.fn(this).upcase
-      end
+      template.register_helper(:upper, <<~JS)
+        function(options) {
+          return options.fn(this).toUpperCase();
+        }
+      JS
 
       template.render.must_equal "HELLO, WORLD."
     end
 
     it "applies block helper to nested values" do
       template = make_template "{{#upper}}Hey {{name}}{{/upper}}!"
-      template.register_helper(:upper) do |this, block|
-        block.fn(this).upcase
-      end
+      template.register_helper(:upper, <<~JS)
+      function(options) {
+        return options.fn(this).toUpperCase();
+      }
+    JS
 
       template.render(nil, name: "Joe").must_equal "HEY JOE!"
     end
 
     it "displays properties from object using 'with' helper" do
       template = make_template "{{#with person}}Hello, {{ first_name }} {{ last_name }}{{/with}}"
-      joe = Person.new "Joe", "Blow"
-      template.render(nil, person: joe).must_equal "Hello, Joe Blow"
+      joe = HashPerson.new "Joe", "Blow"
+      template.render(nil, person: joe.to_h).must_equal "Hello, Joe Blow"
     end
   end
 
@@ -259,12 +263,12 @@ describe Tilt::HandlebarsTemplate do
     it "raises error if partial cannot be found" do
       template = Tilt.new("test/fixtures/views/missing_partial.hbs")
       # template.render
-      proc { template.render }.must_raise V8::Error
+      proc { template.render }.must_raise
     end
 
     it "cannot automatically load partial when template is created from string instead of file" do
       template = make_template "I wish I could load a partial like this: {{> my_partial}}."
-      proc { template.render }.must_raise V8::Error
+      proc { template.render }.must_raise
     end
 
     it "allows partial to be registered" do

--- a/tilt-handlebars.gemspec
+++ b/tilt-handlebars.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
 
-  spec.add_dependency "handlebars", "~> 0.7"
+  spec.add_dependency "handlebars-engine"
   spec.add_dependency "tilt", ">= 1.3"
 
   spec.add_development_dependency "appraisal"


### PR DESCRIPTION
This updates the Handlebars engine to remove any dependency on `therubyracer`.
The `handlebars-engine` gem uses the `mini_racer` gem instead.

See https://github.com/gi/handlebars-ruby
See https://rubygems.org/gems/handlebars-engine

Fixes #7.